### PR TITLE
Added TargetFramework property to individual configurations in Transitionz library

### DIFF
--- a/SciChart.Wpf.UI.Transitionz/SciChart.Wpf.UI.Transitionz.csproj
+++ b/SciChart.Wpf.UI.Transitionz/SciChart.Wpf.UI.Transitionz.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SciChart.Wpf.UI.Transitionz</RootNamespace>
     <AssemblyName>SciChart.Wpf.UI.Transitionz</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +22,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Build\Debug\SciChart.Wpf.UI.Transitionz.XML</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +33,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Build\Release\SciChart.Wpf.UI.Transitionz.XML</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release45|AnyCPU'">
     <OutputPath>..\Build\Release\net45\</OutputPath>
@@ -44,6 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release46|AnyCPU'">
     <OutputPath>..\Build\Release\net46\</OutputPath>
@@ -55,6 +57,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
The current NuGet package includes three different DLLs, and claims that they are targeted for net40, net45, and net461.

However, upon examining the DLLs in the current release, you'll find that all DLLs have been built to target net461, even though they may be in the net45 or the net40 folders. 

This change corrects the Transitonz csproj file to target the correct frameworks.